### PR TITLE
kakao 로그인 Oauth token 인증해제 성공

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,20 +2,26 @@ const epxress = require('express');
 const app = epxress();
 const https = require('https');
 const http = require('http');
-const port = 3333 || 443;
+const port = 3333 ?? 443;
 const path = require('path');
 const axios = require('axios');
+const store = require('store');
+const cors = require('cors');
 const fs = require('fs');
 const qs = require('qs');
 require('dotenv').config();
 
-// process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
 //html을 렌더링하기 위한 부품, pug, ejs
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
-// app.set('views', './views');
 
+let corsOption = {
+  Credential: true,
+};
+//
+app.use(cors(corsOption));
 app.get('/', (req, res) => {
   // res.send("Root")
   res.render('index.ejs');
@@ -24,54 +30,73 @@ app.get('/', (req, res) => {
 const kakao_info = {
   clientID: process.env.KAKAO_CLIENT_ID,
   client_secret: process.env.KAKAO_CLIENT_SECRET,
-  redirect_url: 'https://localhost:3333/oauth/kakao/login',
+  client_admin: process.env.KAKAO_ADMIN_KEY,
+  redirect_url: `https://localhost:3333/oauth/kakao/login`,
 };
 
 /* 카카오 인증 확인 */
 app.get('/oauth/kakao', (req, res) => {
-  const kakao_url = `https://kauth.kakao.com/oauth/authorize?client_id=${kakao_info.clientID}&redirect_uri=${kakao_info.redirect_url}&response_type=code`;
-  res.redirect(kakao_url);
+  const kakao_url = `https://kauth.kakao.com/oauth/authorize?client_id=${kakao_info.clientID}&redirect_uri=${kakao_info.redirect_url}&response_type=code&scope=profile_nickname,profile_image,account_email`;
+  res.status(302).redirect(kakao_url);
 });
 
 /* 카카오 발급 */
-//카카오 리디렉트 주소를 설정 후
-// app.get('/oauth/kakao/login', async (req, res) => {
-//   let token;
-//   try {
-//     token = await axios({
-//       method: 'POST',
-//       url: 'https://kauth.kakao.com/oauth/token',
-//       headers: {
-//         'content-type': 'application/x-www-form-urlencoded',
-//       },
-//       data: qs.stringify({
-//         grant_type: 'authorization_code',
-//         client_id: kakao_info.clientID,
-//         client_secret: kakao_info.client_secret,
-//         redirect_uri: kakao_info.redirect_url,
-//         code: req.query.code,
-//       }),
-//     });
-//   } catch (error) {
-//     console.log(error.message);
-//   }
+//카카오 리디렉트 주소를 설정 후, get으로 인증 주소를 가져온다.
+app.get('/oauth/kakao/login', async (req, res) => {
+  let token;
 
-//   console.log(token);
-//   let user;
-//   try {
-//     user = await axios({
-//       method: 'GET',
-//       url: 'https://kapi.kakao.com/v2/user/me',
-//       headers: {
-//         Authorization: `Bearer ${token.data.access_token}`,
-//       },
-//     });
-//     console.log(user);
-//   } catch (error) {
-//     console.log(error.message);
-//   }
-//   // res.status(200).send('Success');
-// });
+  try {
+    token = await axios({
+      method: 'POST',
+      url: 'https://kauth.kakao.com/oauth/token',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      data: qs.stringify({
+        grant_type: 'authorization_code',
+        client_id: kakao_info.clientID,
+        client_secret: kakao_info.client_secret,
+        redirect_uri: kakao_info.redirect_url,
+        code: req.query.code,
+      }),
+    });
+  } catch (error) {
+    console.log(error.message);
+  }
+  let testKkoTk = token.data.access_token;
+  console.log(token.data.access_token);
+  store.set('testKkoTk', testKkoTk);
+
+  console.log(testKkoTk);
+
+  let user;
+  try {
+    user = await axios({
+      method: 'GET',
+      url: 'https://kapi.kakao.com/v2/user/me',
+      headers: {
+        Authorization: `Bearer ${token.data.access_token}`,
+      },
+    });
+    console.log(user.data);
+  } catch (error) {
+    console.log(error.message);
+  }
+});
+
+/* 카카오 인증 연결 끊기 */
+app.get(`/oauth/kakao/unlink`, async (req, res) => {
+  const targetTk = store.get('testKkoTk');
+  await axios({
+    method: 'POST',
+    url: `https://kapi.kakao.com/v1/user/unlink`,
+    headers: {
+      Authorization: `Bearer ${targetTk}`,
+    },
+  });
+
+  res.status(302).redirect('/');
+});
 
 //Openssl을 이용한 인증서
 const sslOption = {
@@ -80,3 +105,4 @@ const sslOption = {
 };
 
 https.createServer(sslOption, app).listen(port);
+// app.listen(port);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^0.24.0",
+        "cors": "^2.8.5",
         "dotenv": "^11.0.0",
         "ejs": "^3.1.6",
         "express": "^4.17.2",
@@ -18,7 +19,8 @@
         "nodemon": "^2.0.15",
         "pug": "^3.0.2",
         "qs": "^6.10.3",
-        "session": "^0.1.0"
+        "session": "^0.1.0",
+        "store": "^2.0.12"
       },
       "devDependencies": {
         "eslint": "^8.6.0",
@@ -678,6 +680,18 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -2895,6 +2909,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/store": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/store/-/store-2.0.12.tgz",
+      "integrity": "sha1-jFNOKguDH3K3X8XxEZhXxE711ZM=",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -3789,6 +3811,15 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -5494,6 +5525,11 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "store": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/store/-/store-2.0.12.tgz",
+      "integrity": "sha1-jFNOKguDH3K3X8XxEZhXxE711ZM="
     },
     "string-width": {
       "version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/hsh411/Test_Social_Login#readme",
   "dependencies": {
     "axios": "^0.24.0",
+    "cors": "^2.8.5",
     "dotenv": "^11.0.0",
     "ejs": "^3.1.6",
     "express": "^4.17.2",
@@ -28,7 +29,8 @@
     "nodemon": "^2.0.15",
     "pug": "^3.0.2",
     "qs": "^6.10.3",
-    "session": "^0.1.0"
+    "session": "^0.1.0",
+    "store": "^2.0.12"
   },
   "devDependencies": {
     "eslint": "^8.6.0",

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -12,6 +12,6 @@
     <!-- 카카오 로그인 -->
     <H1>카카오 로그인</H1>
     <a href="/oauth/kakao">카카오 로그인</a>
-    <a href="/oauth/kakao/user_info">카카오 정보</a>
+    <a href="/oauth/kakao/unlink">연결 끊기</a>
   </body>
 </html>


### PR DESCRIPTION
브라우저에는 모든 객체의 조상이 되는 Window객체에서  

Cookie처럼 클라이언트(브라우저, 로컬)상에 키와 값으로 저장하는 기능중 하나인

LocalStorage를 활용해보려 했으나 서버사이드로 

Nodejs에서 접근하려 했기에 Localstorage는 사용을 못하였다. 그래서 비슷한 기능을 가진 라이브러리 Store를 통해 액세스 토큰을 저장 후

인증 해제시 불러오는 너무 쉬운 작업을 통해 Oauth2.0 인증해제에 성공.