### PR TITLE
Google base

### DIFF
--- a/app.js
+++ b/app.js
@@ -67,7 +67,7 @@ app.use(
 /* Router */
 app.use(main);
 app.use('/oauth/', social);
-
+// app.use()
 //Openssl을 이용한 인증서
 const sslOption = {
   key: fs.readFileSync('./lh.key'),

--- a/routers/social.js
+++ b/routers/social.js
@@ -8,6 +8,7 @@ const {
   kakao_profile,
   kakao_unlink,
   google_login,
+  google_check,
 } = require('../controllers/Oauth.social.login');
 
 /* 카카오 라우터 */
@@ -18,5 +19,6 @@ router.get('/kakao/logout', authentication, kakao_logout);
 router.get('/kakao/unlink', authentication, kakao_unlink);
 
 /* 구글 라우터 */
-router.get('/google', google_login);
+router.get('/google', google_check);
+router.get('/google/login', google_login);
 module.exports = router;

--- a/routers/social.js
+++ b/routers/social.js
@@ -9,6 +9,7 @@ const {
   kakao_unlink,
   google_login,
   google_check,
+  google_profile,
 } = require('../controllers/Oauth.social.login');
 
 /* 카카오 라우터 */
@@ -21,4 +22,5 @@ router.get('/kakao/unlink', authentication, kakao_unlink);
 /* 구글 라우터 */
 router.get('/google', google_check);
 router.get('/google/login', google_login);
+router.get('/google/account_info', google_profile);
 module.exports = router;

--- a/views/pages/index.ejs
+++ b/views/pages/index.ejs
@@ -20,6 +20,7 @@
     <div>
       <H1>구글 로그인</H1>
       <a href="/oauth/google">구글 로그인</a>
+      <a href="/oauth/google/account_info">구글 프로필</a>
       <script src="https://accounts.google.com/gsi/client" async defer></script>
     </div>
   </body>


### PR DESCRIPTION
Oauth 2.0 기존 방식으로 구글 로그인 구현

페이스북, 깃헙,  네이버 등등 각 Oauth2.0 기반 로그인 구현은 이대로 비슷할 거라 예상

이번에는 방법을 변경해서 작업 예정

기존 : 클라(View) => 리소스 서버(req, res) => 인증서버(res) => 리소스서버(req, res) => 클라(View)

메뉴얼 방식: 클라 => 인증 서버 => 클라
                   리소스 서버=> 인증 서버 => 리소스 서버
                   클라 => 리소스 서버 => 클라

방식으로 작업

ex) 추가계획

Passport 라이브러리를 활용한 Oauth2.0 기반 소셜로구인 구현
Mysql 활용해 사용자 정보 저장(쿠키나 세션은 사용자 개인 정보를 담지 않음)